### PR TITLE
fix for delete request failures

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -104,7 +104,8 @@ Client.prototype.requestJson = function (method, path, query) {
       res.getBody();
       return;
     }
-    var body = JSON.parse(res.getBody());
+    var body = res.getBody();
+    body = body.length ? JSON.parse(body) : {};
     if (res.headers.link) {
       var link = parseLinks(res.headers.link);
       for (var i = 0; i < LINK_TYPES.length; i++) {


### PR DESCRIPTION
github api returns empty bodies for delete requests, causing JSON.parse to throw a syntax error for empty strings. 

check length of body response before JSON.parsing, else simply assign an empty object